### PR TITLE
feat: session list page with table, status badges, and loading skeleton

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 dist
 node_modules
 CLAUDE.md
+.vite

--- a/src/pages/SessionList.tsx
+++ b/src/pages/SessionList.tsx
@@ -1,36 +1,114 @@
 import { Link } from 'react-router-dom'
 import { useSessionList } from '../hooks/useSession.ts'
+import type { SessionSummary } from '../api/types.ts'
+
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    complete: 'bg-green-100 text-green-800',
+    optimizing: 'bg-yellow-100 text-yellow-800',
+    running: 'bg-yellow-100 text-yellow-800',
+    failed: 'bg-red-100 text-red-800',
+    error: 'bg-red-100 text-red-800',
+  }
+  const cls = colors[status.toLowerCase()] ?? 'bg-gray-100 text-gray-800'
+  return (
+    <span
+      className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${cls}`}
+    >
+      {status}
+    </span>
+  )
+}
+
+function formatDate(iso: string) {
+  try {
+    return new Date(iso).toLocaleString()
+  } catch {
+    return iso
+  }
+}
+
+function SkeletonRow() {
+  return (
+    <tr className="animate-pulse">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <td key={i} className="px-4 py-3">
+          <div className="h-4 rounded bg-gray-200" />
+        </td>
+      ))}
+    </tr>
+  )
+}
+
+function SessionRow({ session }: { session: SessionSummary }) {
+  return (
+    <tr className="border-b hover:bg-gray-50">
+      <td className="px-4 py-3 font-mono text-sm">{session.session_id}</td>
+      <td className="px-4 py-3">
+        <Link
+          to={`/sessions/${session.session_id}`}
+          className="text-blue-600 hover:underline"
+        >
+          {session.goal}
+        </Link>
+      </td>
+      <td className="px-4 py-3">
+        <StatusBadge status={session.status} />
+      </td>
+      <td className="px-4 py-3 text-center">
+        {session.iteration}/{session.max_iterations}
+      </td>
+      <td className="px-4 py-3">{session.platform}</td>
+      <td className="px-4 py-3 text-sm text-gray-500">{formatDate(session.saved_at)}</td>
+    </tr>
+  )
+}
 
 export default function SessionList() {
   const { data: sessions, isLoading, error } = useSessionList()
 
-  if (isLoading) return <p className="p-8 text-gray-500">Loading sessions...</p>
-  if (error)
-    return <p className="p-8 text-red-600">Error loading sessions: {String(error)}</p>
-
   return (
-    <div className="mx-auto max-w-5xl p-8">
+    <div className="mx-auto max-w-6xl p-8">
       <h1 className="mb-6 text-2xl font-bold">Design Sessions</h1>
-      {sessions && sessions.length === 0 && (
-        <p className="text-gray-500">No sessions found.</p>
+
+      {error && (
+        <p className="mb-4 text-red-600">Error loading sessions: {String(error)}</p>
       )}
-      <div className="space-y-2">
-        {sessions?.map((s) => (
-          <Link
-            key={s.session_id}
-            to={`/sessions/${s.session_id}`}
-            className="block rounded border p-4 hover:bg-gray-50"
-          >
-            <div className="flex items-center justify-between">
-              <span className="font-medium">{s.goal}</span>
-              <span className="text-sm text-gray-500">{s.status}</span>
-            </div>
-            <div className="mt-1 text-sm text-gray-400">
-              {s.platform} &middot; iteration {s.iteration}/{s.max_iterations}
-            </div>
-          </Link>
-        ))}
-      </div>
+
+      {!isLoading && !error && sessions?.length === 0 && (
+        <div className="rounded-lg border-2 border-dashed border-gray-300 p-12 text-center">
+          <p className="text-gray-500">No sessions found</p>
+          <p className="mt-2 text-sm text-gray-400">
+            Run{' '}
+            <code className="rounded bg-gray-100 px-1.5 py-0.5 font-mono text-sm">
+              branes design plan
+            </code>{' '}
+            to create one
+          </p>
+        </div>
+      )}
+
+      {(isLoading || (sessions && sessions.length > 0)) && (
+        <div className="overflow-x-auto rounded-lg border">
+          <table className="w-full text-left text-sm">
+            <thead className="border-b bg-gray-50 text-xs uppercase text-gray-500">
+              <tr>
+                <th className="px-4 py-3">Session ID</th>
+                <th className="px-4 py-3">Goal</th>
+                <th className="px-4 py-3">Status</th>
+                <th className="px-4 py-3 text-center">Iteration</th>
+                <th className="px-4 py-3">Platform</th>
+                <th className="px-4 py-3">Saved At</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading
+                ? Array.from({ length: 5 }).map((_, i) => <SkeletonRow key={i} />)
+                : sessions?.map((s) => <SessionRow key={s.session_id} session={s} />)}
+            </tbody>
+          </table>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- Full session list table with columns: Session ID, Goal, Status, Iteration, Platform, Saved At
- Color-coded status badges: green (complete), yellow (optimizing/running), red (failed/error), gray (other)
- Animated loading skeleton while fetching
- Empty state with prompt to run `branes design plan`
- Auto-refresh every 10s via TanStack Query `refetchInterval`

## Test plan

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` succeeds
- [x] Empty state shows when no sessions exist (backend running, no sessions)
- [x] Loading skeleton displays briefly on initial load
- [x] Session rows render correctly when sessions exist
- [x] Clicking a goal link navigates to `/sessions/{id}`

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/claude-code)