### PR TITLE
feat: session detail page with header, metric cards, and tab navigation

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -23,6 +23,11 @@ export interface SoCDesignState {
   goal: string
   status: string
   iteration: number
+  max_iterations?: number
+  platform?: string
+  use_case?: string
+  constraints?: Record<string, number>
+  ppa_metrics?: Record<string, unknown>
   [key: string]: unknown
 }
 

--- a/src/components/MetricCard.tsx
+++ b/src/components/MetricCard.tsx
@@ -1,0 +1,60 @@
+interface Props {
+  label: string
+  value: number | null | undefined
+  unit: string
+  budget: number | null | undefined
+  verdict?: string
+}
+
+export default function MetricCard({ label, value, unit, budget, verdict }: Props) {
+  const pct =
+    value != null && budget != null && budget > 0
+      ? Math.min((value / budget) * 100, 100)
+      : null
+
+  const isPass = verdict?.toUpperCase() === 'PASS'
+  const isFail = verdict?.toUpperCase() === 'FAIL'
+
+  return (
+    <div className="rounded-lg border bg-white p-4 shadow-sm">
+      <div className="mb-1 text-xs font-medium uppercase tracking-wide text-gray-500">
+        {label}
+      </div>
+      <div className="flex items-baseline gap-1.5">
+        <span className="text-2xl font-bold">
+          {value != null ? value.toFixed(1) : '—'}
+        </span>
+        <span className="text-sm text-gray-400">{unit}</span>
+        {verdict && (
+          <span
+            className={`ml-auto rounded-full px-2 py-0.5 text-xs font-medium ${
+              isPass
+                ? 'bg-green-100 text-green-800'
+                : isFail
+                  ? 'bg-red-100 text-red-800'
+                  : 'bg-gray-100 text-gray-800'
+            }`}
+          >
+            {verdict}
+          </span>
+        )}
+      </div>
+      {pct != null && budget != null && (
+        <div className="mt-3">
+          <div className="mb-1 flex justify-between text-xs text-gray-400">
+            <span>0</span>
+            <span>
+              {budget} {unit}
+            </span>
+          </div>
+          <div className="h-2 w-full rounded-full bg-gray-100">
+            <div
+              className={`h-2 rounded-full ${isPass ? 'bg-green-500' : isFail ? 'bg-red-500' : 'bg-blue-500'}`}
+              style={{ width: `${pct}%` }}
+            />
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/SessionHeader.tsx
+++ b/src/components/SessionHeader.tsx
@@ -1,0 +1,47 @@
+interface Props {
+  goal: string
+  platform: string
+  status: string
+  iteration: number
+  maxIterations?: number
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const colors: Record<string, string> = {
+    complete: 'bg-green-100 text-green-800',
+    optimizing: 'bg-yellow-100 text-yellow-800',
+    running: 'bg-yellow-100 text-yellow-800',
+    failed: 'bg-red-100 text-red-800',
+    error: 'bg-red-100 text-red-800',
+  }
+  const cls = colors[status.toLowerCase()] ?? 'bg-gray-100 text-gray-800'
+  return (
+    <span
+      className={`inline-block rounded-full px-2.5 py-0.5 text-xs font-medium ${cls}`}
+    >
+      {status}
+    </span>
+  )
+}
+
+export default function SessionHeader({
+  goal,
+  platform,
+  status,
+  iteration,
+  maxIterations = 20,
+}: Props) {
+  return (
+    <div className="mb-6">
+      <h1 className="text-2xl font-bold">{goal}</h1>
+      <div className="mt-2 flex items-center gap-3 text-sm text-gray-500">
+        <StatusBadge status={status} />
+        <span>{platform}</span>
+        <span>&middot;</span>
+        <span>
+          iteration {iteration}/{maxIterations}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/SessionDetail.tsx
+++ b/src/pages/SessionDetail.tsx
@@ -1,22 +1,88 @@
+import { useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
 import { useSession } from '../hooks/useSession.ts'
+import SessionHeader from '../components/SessionHeader.tsx'
+import MetricCard from '../components/MetricCard.tsx'
+
+const TABS = ['Overview', 'Optimization', 'Architecture', 'SWaP-C', 'Decisions'] as const
+type Tab = (typeof TABS)[number]
+
+const METRIC_DEFS = [
+  { key: 'power_watts', label: 'Power', unit: 'W' },
+  { key: 'latency_ms', label: 'Latency', unit: 'ms' },
+  { key: 'cost_usd', label: 'Cost', unit: 'USD' },
+  { key: 'area_mm2', label: 'Area', unit: 'mm²' },
+] as const
 
 export default function SessionDetail() {
   const { id } = useParams<{ id: string }>()
   const { data: session, isLoading, error } = useSession(id!)
+  const [activeTab, setActiveTab] = useState<Tab>('Overview')
 
   if (isLoading) return <p className="p-8 text-gray-500">Loading session...</p>
   if (error) return <p className="p-8 text-red-600">Error: {String(error)}</p>
+  if (!session) return null
+
+  const ppa = (session.ppa_metrics ?? {}) as Record<string, unknown>
+  const verdicts = (ppa.verdicts ?? {}) as Record<string, string>
+  const constraints = (session.constraints ?? {}) as Record<string, number>
 
   return (
-    <div className="mx-auto max-w-5xl p-8">
-      <Link to="/" className="text-blue-600 hover:underline">
-        &larr; Back to sessions
-      </Link>
-      <h1 className="mt-4 text-2xl font-bold">{session?.goal}</h1>
-      <p className="mt-1 text-gray-500">
-        {session?.status} &middot; iteration {session?.iteration}
-      </p>
+    <div className="mx-auto max-w-6xl p-8">
+      {/* Breadcrumb */}
+      <nav className="mb-4 text-sm text-gray-500">
+        <Link to="/" className="text-blue-600 hover:underline">
+          Sessions
+        </Link>
+        <span className="mx-2">/</span>
+        <span>{session.session_id}</span>
+      </nav>
+
+      <SessionHeader
+        goal={session.goal}
+        platform={String(session.platform ?? '')}
+        status={session.status}
+        iteration={session.iteration}
+        maxIterations={Number(session.max_iterations ?? 20)}
+      />
+
+      {/* Metric Cards */}
+      <div className="mb-8 grid grid-cols-2 gap-4 lg:grid-cols-4">
+        {METRIC_DEFS.map((m) => (
+          <MetricCard
+            key={m.key}
+            label={m.label}
+            value={ppa[m.key] as number | undefined}
+            unit={m.unit}
+            budget={constraints[m.key]}
+            verdict={verdicts[m.key]}
+          />
+        ))}
+      </div>
+
+      {/* Tab Panel */}
+      <div className="border-b">
+        <nav className="-mb-px flex gap-6">
+          {TABS.map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`border-b-2 px-1 py-3 text-sm font-medium ${
+                activeTab === tab
+                  ? 'border-blue-600 text-blue-600'
+                  : 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'
+              }`}
+            >
+              {tab}
+            </button>
+          ))}
+        </nav>
+      </div>
+
+      {/* Tab Content Placeholder */}
+      <div className="py-8 text-center text-gray-400">
+        {activeTab} tab — visualizations coming soon
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **SessionHeader** component: displays goal, platform, color-coded status badge, iteration counter
- **MetricCard** component: shows metric value + unit, verdict badge (PASS/FAIL), budget progress bar with color coding
- **SessionDetail** page layout: breadcrumb nav → header → 4 metric cards (Power, Latency, Cost, Area) → 5-tab panel (Overview, Optimization, Architecture, SWaP-C, Decisions)
- Extended `SoCDesignState` type with `ppa_metrics`, `constraints`, `platform`, `max_iterations`

## Test plan

- [x] `npm run lint && npm run typecheck && npm run build` all pass
- [x] Navigate from session list to session detail via clicking a goal link
- [x] Breadcrumb shows "Sessions / {session_id}" with working back link
- [x] Header shows goal, platform, status badge, iteration
- [x] Metric cards show values with budget bars (green for PASS, red for FAIL)
- [x] Tabs switch between Overview, Optimization, Architecture, SWaP-C, Decisions
- [x] Test with soc_test001 (all PASS) and soc_test002 (power FAIL)

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/claude-code)