### PR TITLE
feat: constraint slackness bar chart with budget markers and trends

### DIFF
--- a/src/components/SlacknessBars.tsx
+++ b/src/components/SlacknessBars.tsx
@@ -1,0 +1,85 @@
+import type { SlacknessEntry } from '../api/types.ts'
+
+interface Props {
+  data: SlacknessEntry[]
+  onBarClick?: (name: string) => void
+}
+
+function barColor(marginPct: number): string {
+  if (marginPct < 5) return 'bg-red-500'
+  if (marginPct < 20) return 'bg-yellow-500'
+  return 'bg-green-500'
+}
+
+function trendIndicator(trend: string) {
+  switch (trend.toLowerCase()) {
+    case 'improving':
+      return <span className="text-green-600">&#9650;</span>
+    case 'worsening':
+      return <span className="text-red-600">&#9660;</span>
+    default:
+      return <span className="text-gray-400">&#8212;</span>
+  }
+}
+
+export default function SlacknessBars({ data, onBarClick }: Props) {
+  // Find max target to normalize bar widths
+  const maxTarget = Math.max(...data.map((d) => d.target), 1)
+
+  return (
+    <div className="space-y-4">
+      {data.map((entry) => {
+        const actualPct = Math.min((entry.actual / maxTarget) * 100, 100)
+        const targetPct = (entry.target / maxTarget) * 100
+
+        return (
+          <button
+            key={entry.name}
+            onClick={() => onBarClick?.(entry.name)}
+            className="block w-full text-left"
+          >
+            <div className="mb-1 flex items-center justify-between text-sm">
+              <span className="font-medium capitalize">
+                {entry.name}
+                {entry.binding && (
+                  <span className="ml-1 text-red-600" title="Binding constraint">
+                    !
+                  </span>
+                )}
+              </span>
+              <span className="flex items-center gap-2 text-gray-500">
+                <span>
+                  {entry.actual.toFixed(1)} / {entry.target.toFixed(1)} {entry.unit}
+                </span>
+                <span
+                  className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                    entry.verdict === 'PASS'
+                      ? 'bg-green-100 text-green-800'
+                      : 'bg-red-100 text-red-800'
+                  }`}
+                >
+                  {entry.margin_pct >= 0 ? '+' : ''}
+                  {entry.margin_pct.toFixed(1)}%
+                </span>
+                {trendIndicator(entry.trend)}
+              </span>
+            </div>
+            <div className="relative h-4 w-full rounded-full bg-gray-100">
+              {/* Actual value bar */}
+              <div
+                className={`h-4 rounded-full ${barColor(entry.margin_pct)} transition-all`}
+                style={{ width: `${actualPct}%` }}
+              />
+              {/* Target marker */}
+              <div
+                className="absolute top-0 h-4 w-0.5 bg-gray-800"
+                style={{ left: `${targetPct}%` }}
+                title={`Target: ${entry.target} ${entry.unit}`}
+              />
+            </div>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/pages/SessionDetail.tsx
+++ b/src/pages/SessionDetail.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
-import { useSession, usePareto } from '../hooks/useSession.ts'
+import { useSession, usePareto, useSlackness } from '../hooks/useSession.ts'
 import SessionHeader from '../components/SessionHeader.tsx'
 import MetricCard from '../components/MetricCard.tsx'
 import ParetoScatter from '../components/ParetoScatter.tsx'
+import SlacknessBars from '../components/SlacknessBars.tsx'
 
 const TABS = ['Overview', 'Optimization', 'Architecture', 'SWaP-C', 'Decisions'] as const
 type Tab = (typeof TABS)[number]
@@ -102,18 +103,31 @@ function OverviewTab({
   sessionId: string
   constraints: Record<string, number>
 }) {
-  const { data: pareto, isLoading, error } = usePareto(sessionId)
-
-  if (isLoading) return <p className="text-gray-500">Loading Pareto data...</p>
-  if (error) return <p className="text-red-600">Error loading Pareto data</p>
-  if (!pareto || pareto.points.length === 0) {
-    return <p className="text-gray-400">No Pareto data available for this session.</p>
-  }
+  const { data: pareto, isLoading: paretoLoading } = usePareto(sessionId)
+  const { data: slackness, isLoading: slacknessLoading } = useSlackness(sessionId)
 
   return (
-    <div>
-      <h2 className="mb-4 text-lg font-semibold">Pareto Frontier</h2>
-      <ParetoScatter data={pareto} constraints={constraints} />
+    <div className="grid gap-8 lg:grid-cols-2">
+      <div>
+        <h2 className="mb-4 text-lg font-semibold">Pareto Frontier</h2>
+        {paretoLoading && <p className="text-gray-500">Loading Pareto data...</p>}
+        {pareto && pareto.points.length > 0 ? (
+          <ParetoScatter data={pareto} constraints={constraints} />
+        ) : (
+          !paretoLoading && <p className="text-gray-400">No Pareto data available.</p>
+        )}
+      </div>
+      <div>
+        <h2 className="mb-4 text-lg font-semibold">Constraint Slackness</h2>
+        {slacknessLoading && <p className="text-gray-500">Loading slackness data...</p>}
+        {slackness && slackness.length > 0 ? (
+          <SlacknessBars data={slackness} />
+        ) : (
+          !slacknessLoading && (
+            <p className="text-gray-400">No slackness data available.</p>
+          )
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **SlacknessBars** component: horizontal budget utilization bars per constraint
- Color coding: green (>20% margin), yellow (5-20%), red (<5% or exceeded)
- Vertical target marker on each bar showing the budget limit
- Binding constraint indicator (!) for tight margins
- Trend arrows: green up-arrow (improving), red down-arrow (worsening), dash (stable)
- Margin percentage badge with PASS/FAIL verdict coloring
- Click handler wired for future DrillPanel integration
- Overview tab now shows Pareto scatter + slackness bars side-by-side in 2-column grid

## Test plan

- [x] `npm run lint && npm run typecheck && npm run build` all pass
- [x] soc_test001: all 4 bars green, no binding indicators, improving/stable trends
- [x] soc_test002: power bar red with (!) binding indicator, worsening trend
- [x] Target markers visible as vertical lines on each bar
- [x] Hover over target marker shows tooltip
- [x] Overview tab shows Pareto + Slackness side by side on wide screens

Closes #5

🤖 Generated with [Claude Code](https://claude.ai/claude-code)