### PR TITLE
feat: task graph DAG visualization with Cytoscape.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.1.0",
       "dependencies": {
         "@tanstack/react-query": "^5.75.5",
+        "cytoscape": "^3.33.1",
+        "cytoscape-dagre": "^2.5.0",
         "plotly.js": "^3.4.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -20,6 +22,7 @@
         "@commitlint/config-conventional": "^20.5.0",
         "@eslint/js": "^9.39.4",
         "@tailwindcss/vite": "^4.1.8",
+        "@types/cytoscape": "^3.21.9",
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -1827,6 +1830,13 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/cytoscape": {
+      "version": "3.21.9",
+      "resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.21.9.tgz",
+      "integrity": "sha512-JyrG4tllI6jvuISPjHK9j2Xv/LTbnLekLke5otGStjFluIyA9JjgnvgZrSBsp8cEDpiTjwgZUZwpPv8TSBcoLw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2943,6 +2953,27 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-dagre": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-dagre/-/cytoscape-dagre-2.5.0.tgz",
+      "integrity": "sha512-VG2Knemmshop4kh5fpLO27rYcyUaaDkRw+6PiX4bstpB+QFt0p2oauMrsjVbUamGWQ6YNavh7x2em2uZlzV44g==",
+      "license": "MIT",
+      "dependencies": {
+        "dagre": "^0.8.5"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.22"
+      }
+    },
     "node_modules/d": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
@@ -3088,6 +3119,16 @@
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
       "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/dagre": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/dagre/-/dagre-0.8.5.tgz",
+      "integrity": "sha512-/aTqmnRta7x7MCCpExk7HQL2O4owCT2h8NT//9I1OQ9vt29Pa0BzSAkR5lwFUcQ7491yVi/3CXU9jQ5o0Mn2Sw==",
+      "license": "MIT",
+      "dependencies": {
+        "graphlib": "^2.1.8",
+        "lodash": "^4.17.15"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -4260,6 +4301,15 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
     },
+    "node_modules/graphlib": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz",
+      "integrity": "sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      }
+    },
     "node_modules/grid-index": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
@@ -4975,6 +5025,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@tanstack/react-query": "^5.75.5",
+    "cytoscape": "^3.33.1",
+    "cytoscape-dagre": "^2.5.0",
     "plotly.js": "^3.4.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
@@ -24,6 +26,7 @@
     "@commitlint/config-conventional": "^20.5.0",
     "@eslint/js": "^9.39.4",
     "@tailwindcss/vite": "^4.1.8",
+    "@types/cytoscape": "^3.21.9",
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/src/components/TaskGraph.tsx
+++ b/src/components/TaskGraph.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef } from 'react'
+import cytoscape from 'cytoscape'
+// @ts-expect-error — cytoscape-dagre has no type declarations
+import dagre from 'cytoscape-dagre'
+import type { TaskGraphResponse } from '../api/types.ts'
+
+cytoscape.use(dagre)
+
+interface Props {
+  data: TaskGraphResponse
+  onNodeClick?: (nodeId: string) => void
+}
+
+const STATUS_COLORS: Record<string, string> = {
+  completed: '#22c55e',
+  running: '#3b82f6',
+  pending: '#9ca3af',
+  failed: '#ef4444',
+  ready: '#eab308',
+}
+
+export default function TaskGraph({ data, onNodeClick }: Props) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const cyRef = useRef<cytoscape.Core | null>(null)
+
+  useEffect(() => {
+    if (!containerRef.current || data.nodes.length === 0) return
+
+    const elements: cytoscape.ElementDefinition[] = []
+
+    // Add nodes
+    for (const node of data.nodes) {
+      elements.push({
+        data: {
+          id: node.id,
+          label: `${node.name}\n(${node.agent})`,
+          status: node.status,
+          bgColor: STATUS_COLORS[node.status] ?? STATUS_COLORS.pending,
+        },
+      })
+    }
+
+    // Add edges from dependencies
+    for (const node of data.nodes) {
+      for (const dep of node.dependencies) {
+        elements.push({
+          data: {
+            id: `${dep}->${node.id}`,
+            source: dep,
+            target: node.id,
+          },
+        })
+      }
+    }
+
+    const cy = cytoscape({
+      container: containerRef.current,
+      elements,
+      style: [
+        {
+          selector: 'node',
+          style: {
+            label: 'data(label)',
+            'text-wrap': 'wrap',
+            'text-valign': 'center',
+            'text-halign': 'center',
+            'font-size': '11px',
+            'background-color': 'data(bgColor)',
+            color: '#fff',
+            'text-outline-color': 'data(bgColor)',
+            'text-outline-width': 2,
+            width: 160,
+            height: 50,
+            shape: 'round-rectangle',
+          },
+        },
+        {
+          selector: 'edge',
+          style: {
+            width: 2,
+            'line-color': '#d1d5db',
+            'target-arrow-color': '#9ca3af',
+            'target-arrow-shape': 'triangle',
+            'curve-style': 'bezier',
+          },
+        },
+      ],
+      layout: {
+        name: 'dagre',
+        rankDir: 'TB',
+        nodeSep: 40,
+        rankSep: 60,
+        padding: 20,
+      } as cytoscape.LayoutOptions,
+      userZoomingEnabled: true,
+      userPanningEnabled: true,
+      boxSelectionEnabled: false,
+    })
+
+    cy.on('tap', 'node', (evt) => {
+      const nodeId = evt.target.id()
+      onNodeClick?.(nodeId)
+    })
+
+    cyRef.current = cy
+
+    return () => {
+      cy.destroy()
+      cyRef.current = null
+    }
+  }, [data, onNodeClick])
+
+  if (data.nodes.length === 0) {
+    return <p className="text-gray-400">No task graph available.</p>
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex flex-wrap gap-3 text-xs">
+        {Object.entries(STATUS_COLORS).map(([status, color]) => (
+          <span key={status} className="flex items-center gap-1">
+            <span
+              className="inline-block h-3 w-3 rounded"
+              style={{ backgroundColor: color }}
+            />
+            <span className="capitalize">{status}</span>
+          </span>
+        ))}
+      </div>
+      <div
+        ref={containerRef}
+        className="rounded-lg border bg-white"
+        style={{ height: 450 }}
+      />
+    </div>
+  )
+}

--- a/src/pages/SessionDetail.tsx
+++ b/src/pages/SessionDetail.tsx
@@ -1,10 +1,11 @@
 import { useState } from 'react'
 import { useParams, Link } from 'react-router-dom'
-import { useSession, usePareto, useSlackness } from '../hooks/useSession.ts'
+import { useSession, usePareto, useSlackness, useTaskGraph } from '../hooks/useSession.ts'
 import SessionHeader from '../components/SessionHeader.tsx'
 import MetricCard from '../components/MetricCard.tsx'
 import ParetoScatter from '../components/ParetoScatter.tsx'
 import SlacknessBars from '../components/SlacknessBars.tsx'
+import TaskGraph from '../components/TaskGraph.tsx'
 
 const TABS = ['Overview', 'Optimization', 'Architecture', 'SWaP-C', 'Decisions'] as const
 type Tab = (typeof TABS)[number]
@@ -86,7 +87,8 @@ export default function SessionDetail() {
         {activeTab === 'Overview' && (
           <OverviewTab sessionId={id!} constraints={constraints} />
         )}
-        {activeTab !== 'Overview' && (
+        {activeTab === 'Architecture' && <ArchitectureTab sessionId={id!} />}
+        {activeTab !== 'Overview' && activeTab !== 'Architecture' && (
           <div className="py-8 text-center text-gray-400">
             {activeTab} tab — visualizations coming soon
           </div>
@@ -128,6 +130,24 @@ function OverviewTab({
           )
         )}
       </div>
+    </div>
+  )
+}
+
+function ArchitectureTab({ sessionId }: { sessionId: string }) {
+  const { data: taskGraph, isLoading, error } = useTaskGraph(sessionId)
+
+  if (isLoading) return <p className="text-gray-500">Loading task graph...</p>
+  if (error) return <p className="text-red-600">Error loading task graph</p>
+
+  return (
+    <div>
+      <h2 className="mb-4 text-lg font-semibold">Task Graph</h2>
+      {taskGraph ? (
+        <TaskGraph data={taskGraph} />
+      ) : (
+        <p className="text-gray-400">No task graph available.</p>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **TaskGraph** component using Cytoscape.js with dagre layout (top-to-bottom DAG)
- Node colors by status: green (completed), blue (running), grey (pending), red (failed), yellow (ready)
- Node labels: task name + agent name on round-rectangle shapes
- Edge arrows showing task dependencies
- Zoom/pan enabled, click handler for node selection
- Status color legend above the graph
- Wired into the **Architecture tab** of SessionDetail

## Test plan

- [x] `npm run lint && npm run typecheck && npm run build` all pass
- [x] Navigate to soc_test001 → Architecture tab shows 6-node DAG
- [x] DAG flows top-to-bottom: Analyze workload → Select architecture + Map operators → Evaluate PPA → Optimize design → Generate report
- [x] All nodes green (completed status)
- [x] Edges have arrow heads pointing to dependent tasks
- [x] Zoom and pan work on the graph
- [x] Legend shows all 5 status colors

Closes #6

🤖 Generated with [Claude Code](https://claude.ai/claude-code)