### PR TITLE
feat: SWaP-C radar chart with ECharts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
         "@tanstack/react-query": "^5.75.5",
         "cytoscape": "^3.33.1",
         "cytoscape-dagre": "^2.5.0",
+        "echarts": "^6.0.0",
+        "echarts-for-react": "^3.0.6",
         "plotly.js": "^3.4.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
@@ -3418,6 +3420,36 @@
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
       "license": "ISC"
     },
+    "node_modules/echarts": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-6.0.0.tgz",
+      "integrity": "sha512-Tte/grDQRiETQP4xz3iZWSvoHrkCQtwqd6hs+mifXcjrCuo2iKWbajFObuLJVBlDIJlOzgQPd1hsaKt/3+OMkQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "6.0.0"
+      }
+    },
+    "node_modules/echarts-for-react": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/echarts-for-react/-/echarts-for-react-3.0.6.tgz",
+      "integrity": "sha512-4zqLgTGWS3JvkQDXjzkR1k1CHRdpd6by0988TWMJgnvDytegWLbeP/VNZmMa+0VJx2eD7Y632bi2JquXDgiGJg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "size-sensor": "^1.0.1"
+      },
+      "peerDependencies": {
+        "echarts": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0",
+        "react": "^15.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.331",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.331.tgz",
@@ -3885,7 +3917,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-isnumeric": {
@@ -6529,6 +6560,12 @@
       "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw==",
       "license": "MIT"
     },
+    "node_modules/size-sensor": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/size-sensor/-/size-sensor-1.0.3.tgz",
+      "integrity": "sha512-+k9mJ2/rQMiRmQUcjn+qznch260leIXY8r4FyYKKyRBO/s5UoeMAHGkCJyE1R/4wrIhTJONfyloY55SkE7ve3A==",
+      "license": "ISC"
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -7354,6 +7391,21 @@
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
+    },
+    "node_modules/zrender": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-6.0.0.tgz",
+      "integrity": "sha512-41dFXEEXuJpNecuUQq6JlbybmnHaqqpGlbH1yxnA5V9MMP4SbohSVZsJIwz+zdjQXSSlR1Vc34EgH1zxyTDvhg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
     "@tanstack/react-query": "^5.75.5",
     "cytoscape": "^3.33.1",
     "cytoscape-dagre": "^2.5.0",
+    "echarts": "^6.0.0",
+    "echarts-for-react": "^3.0.6",
     "plotly.js": "^3.4.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",

--- a/src/components/SwapRadar.tsx
+++ b/src/components/SwapRadar.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react'
+import ReactECharts from 'echarts-for-react'
+import type { EChartsOption } from 'echarts'
+
+interface Props {
+  metrics: Record<string, number>
+  constraints: Record<string, number>
+}
+
+const AXES = [
+  { key: 'power_watts', label: 'Power' },
+  { key: 'latency_ms', label: 'Latency' },
+  { key: 'area_mm2', label: 'Area' },
+  { key: 'cost_usd', label: 'Cost' },
+] as const
+
+export default function SwapRadar({ metrics, constraints }: Props) {
+  const [showPercent, setShowPercent] = useState(true)
+
+  const indicators = AXES.map((a) => {
+    const budget = constraints[a.key]
+    return {
+      name: a.label,
+      max: showPercent ? 120 : (budget ?? 100) * 1.5,
+    }
+  })
+
+  const budgetValues = AXES.map((a) => {
+    const budget = constraints[a.key]
+    if (!budget) return 0
+    return showPercent ? 100 : budget
+  })
+
+  const actualValues = AXES.map((a) => {
+    const actual = metrics[a.key]
+    const budget = constraints[a.key]
+    if (actual == null) return 0
+    return showPercent && budget ? (actual / budget) * 100 : actual
+  })
+
+  const option: EChartsOption = {
+    tooltip: {
+      trigger: 'item',
+      formatter: () => {
+        const lines = AXES.map((a) => {
+          const actual = metrics[a.key]
+          const budget = constraints[a.key]
+          const pct =
+            actual != null && budget ? ((actual / budget) * 100).toFixed(0) : '—'
+          return `${a.label}: ${actual?.toFixed(1) ?? '—'} / ${budget?.toFixed(1) ?? '—'} (${pct}%)`
+        })
+        return lines.join('<br/>')
+      },
+    },
+    legend: {
+      data: ['Budget envelope', 'Current design'],
+      bottom: 0,
+    },
+    radar: {
+      indicator: indicators,
+      shape: 'polygon',
+    },
+    series: [
+      {
+        type: 'radar',
+        data: [
+          {
+            name: 'Budget envelope',
+            value: budgetValues,
+            symbol: 'none',
+            lineStyle: { color: '#9ca3af', type: 'dashed', width: 2 },
+            areaStyle: { color: 'rgba(156, 163, 175, 0.1)' },
+          },
+          {
+            name: 'Current design',
+            value: actualValues,
+            symbol: 'circle',
+            symbolSize: 6,
+            lineStyle: { color: '#3b82f6', width: 2 },
+            areaStyle: { color: 'rgba(59, 130, 246, 0.2)' },
+            itemStyle: { color: '#3b82f6' },
+          },
+        ],
+      },
+    ],
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex gap-2">
+        <button
+          onClick={() => setShowPercent(true)}
+          className={`rounded px-3 py-1 text-sm ${
+            showPercent
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+          }`}
+        >
+          % of Budget
+        </button>
+        <button
+          onClick={() => setShowPercent(false)}
+          className={`rounded px-3 py-1 text-sm ${
+            !showPercent
+              ? 'bg-blue-600 text-white'
+              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+          }`}
+        >
+          Absolute
+        </button>
+      </div>
+      <ReactECharts option={option} style={{ height: 450 }} />
+    </div>
+  )
+}

--- a/src/pages/SessionDetail.tsx
+++ b/src/pages/SessionDetail.tsx
@@ -13,6 +13,7 @@ import ParetoScatter from '../components/ParetoScatter.tsx'
 import SlacknessBars from '../components/SlacknessBars.tsx'
 import TaskGraph from '../components/TaskGraph.tsx'
 import TrajectoryChart from '../components/TrajectoryChart.tsx'
+import SwapRadar from '../components/SwapRadar.tsx'
 
 const TABS = ['Overview', 'Optimization', 'Architecture', 'SWaP-C', 'Decisions'] as const
 type Tab = (typeof TABS)[number]
@@ -98,13 +99,20 @@ export default function SessionDetail() {
           <OptimizationTab sessionId={id!} constraints={constraints} />
         )}
         {activeTab === 'Architecture' && <ArchitectureTab sessionId={id!} />}
-        {activeTab !== 'Overview' &&
-          activeTab !== 'Optimization' &&
-          activeTab !== 'Architecture' && (
-            <div className="py-8 text-center text-gray-400">
-              {activeTab} tab — visualizations coming soon
-            </div>
-          )}
+        {activeTab === 'SWaP-C' && (
+          <div>
+            <h2 className="mb-4 text-lg font-semibold">SWaP-C Radar</h2>
+            <SwapRadar
+              metrics={ppa as Record<string, number>}
+              constraints={constraints}
+            />
+          </div>
+        )}
+        {activeTab === 'Decisions' && (
+          <div className="py-8 text-center text-gray-400">
+            Decisions tab — visualizations coming soon
+          </div>
+        )}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary

- **SwapRadar** component using ECharts: polygon radar chart with 4 axes (Power, Latency, Area, Cost)
- **Budget envelope**: dashed grey reference polygon with semi-transparent fill showing constraint limits
- **Current design**: solid blue polygon with circle markers showing actual metric values
- **Toggle**: switch between "% of Budget" (normalized 0–120%) and "Absolute" values
- **Hover tooltip**: shows actual vs budget with percentage for all axes
- Wired into **SWaP-C tab** of SessionDetail

## Test plan

- [x] `npm run lint && npm run typecheck && npm run build` all pass
- [x] Navigate to soc_test001 → SWaP-C tab shows radar chart
- [x] Budget envelope (grey dashed) visible as outer polygon
- [x] Current design (blue solid) visible inside budget envelope (all PASS)
- [x] soc_test002: power axis extends beyond budget envelope (FAIL)
- [x] Toggle between % of Budget and Absolute modes works
- [x] Hover shows actual/budget/percentage values

Closes #8

🤖 Generated with [Claude Code](https://claude.ai/claude-code)