### PR TITLE
feat: multi-level metric drill-down treemap with ECharts

### DIFF
--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -79,15 +79,19 @@ export interface TaskGraphResponse {
 
 export interface WorkloadOperator {
   name: string
+  model_class: string
   gflops: number
   memory_mb: number
-  latency_ms: number
-  mapped_to: string
-  bound: string
+  latency_ms?: number
+  mapped_to?: string
+  bound?: string
+  scheduling?: string
 }
 
 export interface WorkloadResponse {
   operators: WorkloadOperator[]
   total_gflops: number
   total_memory_mb: number
+  dominant_op?: string
+  source?: string
 }

--- a/src/components/DrillTree.tsx
+++ b/src/components/DrillTree.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react'
+import ReactECharts from 'echarts-for-react'
+import type { EChartsOption } from 'echarts'
+import type { WorkloadResponse } from '../api/types.ts'
+
+interface Props {
+  data: WorkloadResponse
+  onNodeClick?: (operatorName: string) => void
+}
+
+type Metric = 'gflops' | 'memory_mb'
+
+const METRIC_OPTIONS: { value: Metric; label: string; unit: string }[] = [
+  { value: 'gflops', label: 'Compute', unit: 'GFLOPS' },
+  { value: 'memory_mb', label: 'Memory', unit: 'MB' },
+]
+
+export default function DrillTree({ data, onNodeClick }: Props) {
+  const [metric, setMetric] = useState<Metric>('gflops')
+
+  const currentMetric = METRIC_OPTIONS.find((m) => m.value === metric)!
+
+  const treemapData = data.operators.map((op) => ({
+    name: op.name,
+    value: op[metric] ?? 0,
+    itemStyle: {
+      borderColor: '#fff',
+      borderWidth: 2,
+    },
+  }))
+
+  const total = metric === 'gflops' ? data.total_gflops : data.total_memory_mb
+
+  const option: EChartsOption = {
+    tooltip: {
+      formatter: (params: unknown) => {
+        const p = params as { name: string; value: number }
+        const op = data.operators.find((o) => o.name === p.name)
+        if (!op) return ''
+        const pct = total ? ((p.value / total) * 100).toFixed(1) : '—'
+        return [
+          `<b>${op.name}</b>`,
+          `${currentMetric.label}: ${p.value.toFixed(1)} ${currentMetric.unit} (${pct}%)`,
+          `Class: ${op.model_class}`,
+          op.scheduling ? `Scheduling: ${op.scheduling}` : '',
+        ]
+          .filter(Boolean)
+          .join('<br/>')
+      },
+    },
+    series: [
+      {
+        type: 'treemap',
+        data: treemapData,
+        roam: false,
+        nodeClick: false,
+        breadcrumb: { show: false },
+        label: {
+          show: true,
+          formatter: (params: unknown) => {
+            const p = params as { name: string; value: number }
+            const pct = total ? ((p.value / total) * 100).toFixed(0) : '—'
+            return `${p.name}\n${p.value.toFixed(1)} ${currentMetric.unit}\n(${pct}%)`
+          },
+          fontSize: 12,
+        },
+        levels: [
+          {
+            itemStyle: {
+              borderColor: '#fff',
+              borderWidth: 3,
+              gapWidth: 3,
+            },
+            colorSaturation: [0.3, 0.7],
+          },
+        ],
+      },
+    ],
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center gap-4">
+        <div className="flex gap-2">
+          {METRIC_OPTIONS.map((m) => (
+            <button
+              key={m.value}
+              onClick={() => setMetric(m.value)}
+              className={`rounded px-3 py-1 text-sm ${
+                metric === m.value
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+              }`}
+            >
+              {m.label}
+            </button>
+          ))}
+        </div>
+        {total != null && (
+          <span className="text-sm text-gray-500">
+            Total: {total.toFixed(1)} {currentMetric.unit}
+          </span>
+        )}
+      </div>
+      <ReactECharts
+        option={option}
+        style={{ height: 400 }}
+        onEvents={{
+          click: (params: { name?: string }) => {
+            if (params.name) onNodeClick?.(params.name)
+          },
+        }}
+      />
+
+      {/* Operator detail table */}
+      <div className="mt-4 overflow-x-auto">
+        <table className="w-full text-left text-sm">
+          <thead className="border-b bg-gray-50 text-xs uppercase text-gray-500">
+            <tr>
+              <th className="px-3 py-2">Operator</th>
+              <th className="px-3 py-2">Class</th>
+              <th className="px-3 py-2 text-right">GFLOPS</th>
+              <th className="px-3 py-2 text-right">Memory (MB)</th>
+              <th className="px-3 py-2">Scheduling</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data.operators.map((op) => (
+              <tr key={op.name} className="border-b hover:bg-gray-50">
+                <td className="px-3 py-2 font-medium">{op.name}</td>
+                <td className="px-3 py-2 text-gray-500">{op.model_class}</td>
+                <td className="px-3 py-2 text-right">{op.gflops?.toFixed(1) ?? '—'}</td>
+                <td className="px-3 py-2 text-right">
+                  {op.memory_mb?.toFixed(1) ?? '—'}
+                </td>
+                <td className="px-3 py-2 text-gray-500">{op.scheduling}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/SessionDetail.tsx
+++ b/src/pages/SessionDetail.tsx
@@ -6,6 +6,7 @@ import {
   useSlackness,
   useTaskGraph,
   useTrajectory,
+  useWorkload,
 } from '../hooks/useSession.ts'
 import SessionHeader from '../components/SessionHeader.tsx'
 import MetricCard from '../components/MetricCard.tsx'
@@ -14,6 +15,7 @@ import SlacknessBars from '../components/SlacknessBars.tsx'
 import TaskGraph from '../components/TaskGraph.tsx'
 import TrajectoryChart from '../components/TrajectoryChart.tsx'
 import SwapRadar from '../components/SwapRadar.tsx'
+import DrillTree from '../components/DrillTree.tsx'
 
 const TABS = ['Overview', 'Optimization', 'Architecture', 'SWaP-C', 'Decisions'] as const
 type Tab = (typeof TABS)[number]
@@ -179,19 +181,29 @@ function OptimizationTab({
 }
 
 function ArchitectureTab({ sessionId }: { sessionId: string }) {
-  const { data: taskGraph, isLoading, error } = useTaskGraph(sessionId)
-
-  if (isLoading) return <p className="text-gray-500">Loading task graph...</p>
-  if (error) return <p className="text-red-600">Error loading task graph</p>
+  const { data: taskGraph, isLoading: tgLoading } = useTaskGraph(sessionId)
+  const { data: workload, isLoading: wlLoading } = useWorkload(sessionId)
 
   return (
-    <div>
-      <h2 className="mb-4 text-lg font-semibold">Task Graph</h2>
-      {taskGraph ? (
-        <TaskGraph data={taskGraph} />
-      ) : (
-        <p className="text-gray-400">No task graph available.</p>
-      )}
+    <div className="space-y-8">
+      <div>
+        <h2 className="mb-4 text-lg font-semibold">Task Graph</h2>
+        {tgLoading && <p className="text-gray-500">Loading task graph...</p>}
+        {taskGraph && taskGraph.nodes.length > 0 ? (
+          <TaskGraph data={taskGraph} />
+        ) : (
+          !tgLoading && <p className="text-gray-400">No task graph available.</p>
+        )}
+      </div>
+      <div>
+        <h2 className="mb-4 text-lg font-semibold">Workload Breakdown</h2>
+        {wlLoading && <p className="text-gray-500">Loading workload data...</p>}
+        {workload && workload.operators.length > 0 ? (
+          <DrillTree data={workload} />
+        ) : (
+          !wlLoading && <p className="text-gray-400">No workload data available.</p>
+        )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **DrillTree** component: ECharts treemap showing per-operator workload breakdown
- **Metric selector**: toggle between Compute (GFLOPS) and Memory (MB)
- Treemap blocks sized by metric value with percentage labels
- Hover tooltip: operator name, class, scheduling, metric value + percentage
- Click handler wired for future slide-out detail panel
- **Operator detail table** below treemap with all fields (name, class, GFLOPS, memory, scheduling)
- Updated `WorkloadOperator` type with `model_class`, `scheduling` fields matching actual API response
- Wired into **Architecture tab** below TaskGraph via `useWorkload` hook

## Test plan

- [x] `npm run lint && npm run typecheck && npm run build` all pass
- [x] Navigate to soc_test001 → Architecture tab shows Task Graph + Workload Breakdown
- [x] Treemap shows 4 operators: yolo_detector (largest), feature_tracker, vio_estimator, nms_filter
- [x] Toggle between Compute and Memory modes changes block sizes
- [x] Total displayed next to toggle (12.4 GFLOPS / 24.0 MB)
- [x] Hover shows operator details
- [x] Detail table shows all operators with correct values

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/claude-code)