### PR TITLE
feat: cost breakdown waterfall chart with volume sensitivity

### DIFF
--- a/src/components/CostWaterfall.tsx
+++ b/src/components/CostWaterfall.tsx
@@ -1,0 +1,154 @@
+import { useState, useMemo } from 'react'
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ReferenceLine,
+  ResponsiveContainer,
+  Cell,
+} from 'recharts'
+
+interface CostBreakdown {
+  die_cost: number
+  package_cost: number
+  test_cost: number
+  nre_per_unit: number
+  total: number
+  production_volume?: number
+  nre_total?: number
+}
+
+interface Props {
+  breakdown: CostBreakdown
+  budgetUsd?: number
+}
+
+const SEGMENTS = [
+  { key: 'die_cost', label: 'Die', color: '#3b82f6' },
+  { key: 'package_cost', label: 'Package', color: '#8b5cf6' },
+  { key: 'test_cost', label: 'Test', color: '#06b6d4' },
+  { key: 'nre_per_unit', label: 'NRE/unit', color: '#f59e0b' },
+] as const
+
+export default function CostWaterfall({ breakdown, budgetUsd }: Props) {
+  const defaultVolume = breakdown.production_volume ?? 100000
+  const nreTotal = breakdown.nre_total ?? breakdown.nre_per_unit * defaultVolume
+  const [volume, setVolume] = useState(defaultVolume)
+
+  const adjustedNrePerUnit = nreTotal / volume
+
+  const data = useMemo(() => {
+    const result = SEGMENTS.reduce<{
+      segments: { name: string; value: number; base: number; color: string }[]
+      cumulative: number
+    }>(
+      (acc, seg) => {
+        const value = seg.key === 'nre_per_unit' ? adjustedNrePerUnit : breakdown[seg.key]
+        acc.segments.push({
+          name: seg.label,
+          value: Number(value.toFixed(2)),
+          base: Number(acc.cumulative.toFixed(2)),
+          color: seg.color,
+        })
+        return { segments: acc.segments, cumulative: acc.cumulative + value }
+      },
+      { segments: [], cumulative: 0 },
+    )
+
+    result.segments.push({
+      name: 'Total',
+      value: Number(result.cumulative.toFixed(2)),
+      base: 0,
+      color: '#10b981',
+    })
+
+    return result.segments
+  }, [breakdown, adjustedNrePerUnit])
+
+  const maxCost = Math.max(data[data.length - 1].value, budgetUsd ?? 0) * 1.15
+
+  // Find the largest cost segment (excluding total)
+  const largestSegment = data
+    .slice(0, -1)
+    .reduce((max, seg) => (seg.value > max.value ? seg : max), data[0])
+
+  return (
+    <div>
+      <ResponsiveContainer width="100%" height={350}>
+        <BarChart data={data} margin={{ top: 10, right: 10, left: 10, bottom: 10 }}>
+          <CartesianGrid strokeDasharray="3 3" stroke="#f0f0f0" vertical={false} />
+          <XAxis dataKey="name" />
+          <YAxis
+            domain={[0, maxCost]}
+            label={{ value: 'USD', angle: -90, position: 'insideLeft' }}
+          />
+          <Tooltip
+            formatter={(value, name) => {
+              if (name === 'base') return [null, null]
+              const v = Number(value)
+              const total = data[data.length - 1].value
+              const pct = total > 0 ? ((v / total) * 100).toFixed(1) : '0'
+              return [`$${v.toFixed(2)} (${pct}%)`, 'Cost']
+            }}
+          />
+          {budgetUsd != null && (
+            <ReferenceLine
+              y={budgetUsd}
+              stroke="#ef4444"
+              strokeDasharray="6 4"
+              label={{ value: `Budget $${budgetUsd}`, fill: '#ef4444', fontSize: 12 }}
+            />
+          )}
+          {/* Invisible base bar for waterfall effect */}
+          <Bar dataKey="base" stackId="stack" fill="transparent" />
+          <Bar dataKey="value" stackId="stack" radius={[4, 4, 0, 0]}>
+            {data.map((entry) => (
+              <Cell
+                key={entry.name}
+                fill={entry.color}
+                stroke={entry.name === largestSegment.name ? '#000' : undefined}
+                strokeWidth={entry.name === largestSegment.name ? 2 : 0}
+              />
+            ))}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+
+      {/* Volume slider */}
+      <div className="mt-4 rounded-lg border bg-gray-50 p-4">
+        <div className="flex items-center justify-between text-sm">
+          <label className="font-medium text-gray-700">Production Volume</label>
+          <span className="text-gray-500">
+            {volume.toLocaleString()} units &middot; NRE/unit: $
+            {adjustedNrePerUnit.toFixed(2)}
+          </span>
+        </div>
+        <input
+          type="range"
+          min={1000}
+          max={1000000}
+          step={1000}
+          value={volume}
+          onChange={(e) => setVolume(Number(e.target.value))}
+          className="mt-2 w-full"
+        />
+        <div className="flex justify-between text-xs text-gray-400">
+          <span>1K</span>
+          <span>500K</span>
+          <span>1M</span>
+        </div>
+      </div>
+
+      {/* Cost summary */}
+      <div className="mt-3 text-sm text-gray-500">
+        Largest cost driver:{' '}
+        <span className="font-medium" style={{ color: largestSegment.color }}>
+          {largestSegment.name} (${largestSegment.value.toFixed(2)})
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/SessionDetail.tsx
+++ b/src/pages/SessionDetail.tsx
@@ -17,6 +17,7 @@ import TrajectoryChart from '../components/TrajectoryChart.tsx'
 import SwapRadar from '../components/SwapRadar.tsx'
 import DrillTree from '../components/DrillTree.tsx'
 import DecisionTimeline from '../components/DecisionTimeline.tsx'
+import CostWaterfall from '../components/CostWaterfall.tsx'
 import type { DecisionEntry } from '../components/DecisionTimeline.tsx'
 
 const TABS = ['Overview', 'Optimization', 'Architecture', 'SWaP-C', 'Decisions'] as const
@@ -104,12 +105,33 @@ export default function SessionDetail() {
         )}
         {activeTab === 'Architecture' && <ArchitectureTab sessionId={id!} />}
         {activeTab === 'SWaP-C' && (
-          <div>
-            <h2 className="mb-4 text-lg font-semibold">SWaP-C Radar</h2>
-            <SwapRadar
-              metrics={ppa as Record<string, number>}
-              constraints={constraints}
-            />
+          <div className="space-y-8">
+            <div>
+              <h2 className="mb-4 text-lg font-semibold">SWaP-C Radar</h2>
+              <SwapRadar
+                metrics={ppa as Record<string, number>}
+                constraints={constraints}
+              />
+            </div>
+            {(ppa.cost_breakdown as Record<string, number> | undefined) && (
+              <div>
+                <h2 className="mb-4 text-lg font-semibold">Cost Breakdown</h2>
+                <CostWaterfall
+                  breakdown={
+                    ppa.cost_breakdown as {
+                      die_cost: number
+                      package_cost: number
+                      test_cost: number
+                      nre_per_unit: number
+                      total: number
+                      production_volume?: number
+                      nre_total?: number
+                    }
+                  }
+                  budgetUsd={constraints.cost_usd}
+                />
+              </div>
+            )}
           </div>
         )}
         {activeTab === 'Decisions' && (


### PR DESCRIPTION
## Summary

- **CostWaterfall** component: stacked waterfall chart using Recharts
- Segments: Die (blue), Package (purple), Test (cyan), NRE/unit (amber), Total (green)
- Largest cost driver highlighted with black border outline
- Budget constraint as dashed red reference line at `cost_usd`
- **Production volume slider** (1K–1M units): adjusts NRE/unit in real time
- Hover tooltip shows absolute USD value and percentage of total
- Cost summary below chart identifies the largest cost driver
- Wired into **SWaP-C tab** below the radar chart

## Test plan

- [x] `npm run lint && npm run typecheck && npm run build` all pass
- [x] Navigate to soc_test001 → SWaP-C tab shows radar + cost waterfall
- [x] 5 bars visible: Die ($12), Package ($8), Test ($5), NRE/unit ($10), Total ($35)
- [x] Budget line at $50
- [x] Die bar has black border (largest segment)
- [x] Drag volume slider: NRE/unit decreases as volume increases, total updates
- [x] Hover shows dollar amount and percentage

Closes #11

🤖 Generated with [Claude Code](https://claude.ai/claude-code)