### PR TITLE
feat: session comparison page with side-by-side diff views

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import SessionList from './pages/SessionList.tsx'
 import SessionDetail from './pages/SessionDetail.tsx'
+import SessionCompare from './pages/SessionCompare.tsx'
 
 function App() {
   return (
@@ -8,6 +9,7 @@ function App() {
       <Routes>
         <Route path="/" element={<SessionList />} />
         <Route path="/sessions/:id" element={<SessionDetail />} />
+        <Route path="/compare" element={<SessionCompare />} />
       </Routes>
     </BrowserRouter>
   )

--- a/src/components/MetricDiff.tsx
+++ b/src/components/MetricDiff.tsx
@@ -1,0 +1,67 @@
+interface MetricRow {
+  label: string
+  unit: string
+  valueA: number | undefined
+  valueB: number | undefined
+  budget?: number
+}
+
+interface Props {
+  metrics: MetricRow[]
+  labelA: string
+  labelB: string
+}
+
+function diffColor(a: number | undefined, b: number | undefined): string {
+  if (a == null || b == null) return 'text-gray-400'
+  // Lower is better for PPA metrics
+  if (b < a) return 'text-green-600'
+  if (b > a) return 'text-red-600'
+  return 'text-gray-500'
+}
+
+function formatDiff(a: number | undefined, b: number | undefined): string {
+  if (a == null || b == null) return '—'
+  const diff = b - a
+  const sign = diff > 0 ? '+' : ''
+  return `${sign}${diff.toFixed(1)}`
+}
+
+export default function MetricDiff({ metrics, labelA, labelB }: Props) {
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="border-b bg-gray-50 text-xs uppercase text-gray-500">
+          <tr>
+            <th className="px-3 py-2 text-left">Metric</th>
+            <th className="px-3 py-2 text-right">{labelA}</th>
+            <th className="px-3 py-2 text-right">{labelB}</th>
+            <th className="px-3 py-2 text-right">Diff</th>
+            <th className="px-3 py-2 text-right">Budget</th>
+          </tr>
+        </thead>
+        <tbody>
+          {metrics.map((m) => (
+            <tr key={m.label} className="border-b">
+              <td className="px-3 py-2 font-medium">{m.label}</td>
+              <td className="px-3 py-2 text-right">
+                {m.valueA?.toFixed(1) ?? '—'} {m.unit}
+              </td>
+              <td className="px-3 py-2 text-right">
+                {m.valueB?.toFixed(1) ?? '—'} {m.unit}
+              </td>
+              <td
+                className={`px-3 py-2 text-right font-medium ${diffColor(m.valueA, m.valueB)}`}
+              >
+                {formatDiff(m.valueA, m.valueB)} {m.unit}
+              </td>
+              <td className="px-3 py-2 text-right text-gray-400">
+                {m.budget?.toFixed(1) ?? '—'} {m.unit}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/components/SessionPicker.tsx
+++ b/src/components/SessionPicker.tsx
@@ -1,0 +1,33 @@
+import { useSessionList } from '../hooks/useSession.ts'
+
+interface Props {
+  label: string
+  value: string | null
+  onChange: (sessionId: string) => void
+  exclude?: string | null
+}
+
+export default function SessionPicker({ label, value, onChange, exclude }: Props) {
+  const { data: sessions, isLoading } = useSessionList()
+
+  return (
+    <div>
+      <label className="mb-1 block text-sm font-medium text-gray-700">{label}</label>
+      <select
+        value={value ?? ''}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded border px-3 py-2 text-sm"
+        disabled={isLoading}
+      >
+        <option value="">Select a session...</option>
+        {sessions
+          ?.filter((s) => s.session_id !== exclude)
+          .map((s) => (
+            <option key={s.session_id} value={s.session_id}>
+              {s.session_id} — {s.goal}
+            </option>
+          ))}
+      </select>
+    </div>
+  )
+}

--- a/src/pages/SessionCompare.tsx
+++ b/src/pages/SessionCompare.tsx
@@ -1,0 +1,214 @@
+import { useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useSession, useSlackness } from '../hooks/useSession.ts'
+import SessionPicker from '../components/SessionPicker.tsx'
+import MetricDiff from '../components/MetricDiff.tsx'
+import SwapRadar from '../components/SwapRadar.tsx'
+import type { SlacknessEntry } from '../api/types.ts'
+
+const METRIC_DEFS = [
+  { key: 'power_watts', label: 'Power', unit: 'W' },
+  { key: 'latency_ms', label: 'Latency', unit: 'ms' },
+  { key: 'cost_usd', label: 'Cost', unit: 'USD' },
+  { key: 'area_mm2', label: 'Area', unit: 'mm²' },
+] as const
+
+export default function SessionCompare() {
+  const [idA, setIdA] = useState<string | null>(null)
+  const [idB, setIdB] = useState<string | null>(null)
+
+  return (
+    <div className="mx-auto max-w-6xl p-8">
+      <nav className="mb-4 text-sm text-gray-500">
+        <Link to="/" className="text-blue-600 hover:underline">
+          Sessions
+        </Link>
+        <span className="mx-2">/</span>
+        <span>Compare</span>
+      </nav>
+
+      <h1 className="mb-6 text-2xl font-bold">Compare Sessions</h1>
+
+      <div className="mb-8 grid grid-cols-2 gap-4">
+        <SessionPicker label="Session A" value={idA} onChange={setIdA} exclude={idB} />
+        <SessionPicker label="Session B" value={idB} onChange={setIdB} exclude={idA} />
+      </div>
+
+      {idA && idB ? (
+        <ComparisonView idA={idA} idB={idB} />
+      ) : (
+        <p className="text-center text-gray-400">Select two sessions above to compare.</p>
+      )}
+    </div>
+  )
+}
+
+function ComparisonView({ idA, idB }: { idA: string; idB: string }) {
+  const { data: sessionA, isLoading: loadingA } = useSession(idA)
+  const { data: sessionB, isLoading: loadingB } = useSession(idB)
+  const { data: slacknessA } = useSlackness(idA)
+  const { data: slacknessB } = useSlackness(idB)
+
+  if (loadingA || loadingB) {
+    return <p className="text-gray-500">Loading sessions...</p>
+  }
+  if (!sessionA || !sessionB) {
+    return <p className="text-red-600">Failed to load one or both sessions.</p>
+  }
+
+  const ppaA = (sessionA.ppa_metrics ?? {}) as Record<string, number>
+  const ppaB = (sessionB.ppa_metrics ?? {}) as Record<string, number>
+  const constraintsA = (sessionA.constraints ?? {}) as Record<string, number>
+
+  const diffMetrics = METRIC_DEFS.map((m) => ({
+    label: m.label,
+    unit: m.unit,
+    valueA: ppaA[m.key],
+    valueB: ppaB[m.key],
+    budget: constraintsA[m.key],
+  }))
+
+  return (
+    <div className="space-y-8">
+      {/* Summary */}
+      <div className="grid grid-cols-2 gap-4 text-sm">
+        <div className="rounded border p-3">
+          <p className="font-medium">{sessionA.goal}</p>
+          <p className="text-gray-500">
+            {sessionA.status} · iter {sessionA.iteration}
+          </p>
+        </div>
+        <div className="rounded border p-3">
+          <p className="font-medium">{sessionB.goal}</p>
+          <p className="text-gray-500">
+            {sessionB.status} · iter {sessionB.iteration}
+          </p>
+        </div>
+      </div>
+
+      {/* Metric diff table */}
+      <div>
+        <h2 className="mb-3 text-lg font-semibold">Metric Comparison</h2>
+        <MetricDiff metrics={diffMetrics} labelA={idA} labelB={idB} />
+      </div>
+
+      {/* Overlay radar */}
+      <div>
+        <h2 className="mb-3 text-lg font-semibold">SWaP-C Overlay</h2>
+        <OverlayRadar
+          metricsA={ppaA}
+          metricsB={ppaB}
+          constraints={constraintsA}
+          labelA={idA}
+          labelB={idB}
+        />
+      </div>
+
+      {/* Slackness diff */}
+      {slacknessA && slacknessB && (
+        <div>
+          <h2 className="mb-3 text-lg font-semibold">Constraint Slackness Diff</h2>
+          <SlacknessDiff
+            slacknessA={slacknessA}
+            slacknessB={slacknessB}
+            labelA={idA}
+            labelB={idB}
+          />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function OverlayRadar({
+  metricsA,
+  metricsB,
+  constraints,
+  labelA,
+  labelB,
+}: {
+  metricsA: Record<string, number>
+  metricsB: Record<string, number>
+  constraints: Record<string, number>
+  labelA: string
+  labelB: string
+}) {
+  // Reuse SwapRadar for session A, and render a note about overlay
+  // For a proper overlay we'd need to extend SwapRadar, but for now
+  // show them side by side
+  return (
+    <div className="grid gap-4 lg:grid-cols-2">
+      <div>
+        <p className="mb-2 text-center text-sm font-medium text-gray-500">{labelA}</p>
+        <SwapRadar metrics={metricsA} constraints={constraints} />
+      </div>
+      <div>
+        <p className="mb-2 text-center text-sm font-medium text-gray-500">{labelB}</p>
+        <SwapRadar metrics={metricsB} constraints={constraints} />
+      </div>
+    </div>
+  )
+}
+
+function SlacknessDiff({
+  slacknessA,
+  slacknessB,
+  labelA,
+  labelB,
+}: {
+  slacknessA: SlacknessEntry[]
+  slacknessB: SlacknessEntry[]
+  labelA: string
+  labelB: string
+}) {
+  const bMap = new Map(slacknessB.map((s) => [s.name, s]))
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead className="border-b bg-gray-50 text-xs uppercase text-gray-500">
+          <tr>
+            <th className="px-3 py-2 text-left">Constraint</th>
+            <th className="px-3 py-2 text-right">{labelA} margin</th>
+            <th className="px-3 py-2 text-right">{labelB} margin</th>
+            <th className="px-3 py-2 text-right">Change</th>
+            <th className="px-3 py-2 text-center">Status</th>
+          </tr>
+        </thead>
+        <tbody>
+          {slacknessA.map((a) => {
+            const b = bMap.get(a.name)
+            const marginA = a.margin_pct
+            const marginB = b?.margin_pct ?? 0
+            const diff = marginB - marginA
+            const improved = diff > 0
+            const regressed = diff < 0
+
+            return (
+              <tr key={a.name} className="border-b">
+                <td className="px-3 py-2 font-medium capitalize">{a.name}</td>
+                <td className="px-3 py-2 text-right">{marginA.toFixed(1)}%</td>
+                <td className="px-3 py-2 text-right">{marginB.toFixed(1)}%</td>
+                <td
+                  className={`px-3 py-2 text-right font-medium ${
+                    improved
+                      ? 'text-green-600'
+                      : regressed
+                        ? 'text-red-600'
+                        : 'text-gray-500'
+                  }`}
+                >
+                  {diff > 0 ? '+' : ''}
+                  {diff.toFixed(1)}%
+                </td>
+                <td className="px-3 py-2 text-center">
+                  {improved ? '↑ Better' : regressed ? '↓ Worse' : '—'}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/pages/SessionList.tsx
+++ b/src/pages/SessionList.tsx
@@ -69,7 +69,15 @@ export default function SessionList() {
 
   return (
     <div className="mx-auto max-w-6xl p-8">
-      <h1 className="mb-6 text-2xl font-bold">Design Sessions</h1>
+      <div className="mb-6 flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Design Sessions</h1>
+        <Link
+          to="/compare"
+          className="rounded bg-blue-600 px-4 py-2 text-sm text-white hover:bg-blue-700"
+        >
+          Compare Sessions
+        </Link>
+      </div>
 
       {error && (
         <p className="mb-4 text-red-600">Error loading sessions: {String(error)}</p>


### PR DESCRIPTION
## Summary

- **SessionCompare** page at `/compare` with dual session picker dropdowns
- **SessionPicker** component: dropdown populated from session list, excludes the other selected session
- **MetricDiff** component: side-by-side table comparing PPA metrics with diff column (green = improved, red = regressed) and budget reference
- **SWaP-C radar overlay**: side-by-side radar charts for both sessions against same budget envelope
- **Constraint slackness diff**: margin percentage comparison with change direction indicators (↑ Better / ↓ Worse)
- **"Compare Sessions"** button added to session list page header
- Route `/compare` added to App.tsx

## Test plan

- [x] `npm run lint && npm run typecheck && npm run build` all pass
- [x] Navigate to `/compare` from session list "Compare Sessions" button
- [x] Select soc_test001 as Session A and soc_test002 as Session B
- [x] Session summaries show goal and status for both
- [x] Metric diff table: power shows 4.2 vs 11.3 (red diff), latency shows 28 vs 42 (red)
- [x] SWaP-C radars render side by side
- [x] Slackness diff shows margin changes with ↑/↓ indicators
- [x] Selecting same session in both pickers is prevented

Closes #12

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session comparison: Select two sessions to view side-by-side metric differences and constraint analysis
  * Comparison view displays metric deltas, visual radar overlays, and constraint slackness changes
  * Added "Compare Sessions" button in the sessions list for quick access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->