### PR TITLE
feat: docker compose for local development

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Docker Compose environment variables
+# Copy to .env and adjust for your platform.
+
+# Path to the embodied-ai-architect repo (sibling directory by default)
+BACKEND_REPO=../embodied-ai-architect
+
+# Path to session data directory
+# Linux/macOS/WSL2:
+SESSION_DIR=~/.embodied-ai
+# Windows (PowerShell, if not using WSL2):
+# SESSION_DIR=${USERPROFILE}/.embodied-ai

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,7 @@
+FROM node:22-alpine
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci
+COPY . .
+EXPOSE 3000
+CMD ["npm", "run", "dev"]

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ npm run lint         # ESLint + Prettier check
 npm run typecheck    # TypeScript type checking
 ```
 
+### Docker Compose (frontend + backend)
+
+Start both services with a single command:
+
+```bash
+docker compose up     # starts backend on :8000 and frontend on :3000
+```
+
+Requires the `embodied-ai-architect` repo as a sibling directory (`../embodied-ai-architect`).
+Session data is mounted read-only from `~/.embodied-ai/sessions/`.
+
 ## Tech Stack
 
 | Library        | Purpose                            |

--- a/README.md
+++ b/README.md
@@ -51,11 +51,18 @@ npm run typecheck    # TypeScript type checking
 Start both services with a single command:
 
 ```bash
+cp .env.example .env  # adjust paths if needed
 docker compose up     # starts backend on :8000 and frontend on :3000
 ```
 
 Requires the `embodied-ai-architect` repo as a sibling directory (`../embodied-ai-architect`).
 Session data is mounted read-only from `~/.embodied-ai/sessions/`.
+Paths are configurable via `.env` — see `.env.example`.
+
+**Windows users**: For best results, use WSL2 with Docker Desktop's WSL2 backend.
+Clone both repos inside the WSL2 filesystem (not `/mnt/c/`) for native
+Linux volume performance. If running outside WSL2, set `SESSION_DIR`
+to `${USERPROFILE}/.embodied-ai` in your `.env` file.
 
 ## Tech Stack
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,8 +8,8 @@ services:
     ports:
       - '8000:8000'
     volumes:
-      - ../embodied-ai-architect:/app
-      - ~/.embodied-ai:/root/.embodied-ai:ro
+      - ${BACKEND_REPO:-../embodied-ai-architect}:/app
+      - ${SESSION_DIR:-~/.embodied-ai}:/root/.embodied-ai:ro
     healthcheck:
       test:
         [

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,12 @@ services:
   backend:
     image: python:3.12-slim
     working_dir: /app
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
     command: >
-      bash -c "pip install -e '.[api]' --quiet &&
+      bash -c "apt-get update -qq && apt-get install -y -qq curl >/dev/null 2>&1;
+               pip install -e '.[api]' --quiet &&
                branes api serve --host 0.0.0.0 --port 8000"
     ports:
       - '8000:8000'
@@ -11,29 +15,26 @@ services:
       - ${BACKEND_REPO:-../embodied-ai-architect}:/app
       - ${SESSION_DIR:-~/.embodied-ai}:/root/.embodied-ai:ro
     healthcheck:
-      test:
-        [
-          'CMD',
-          'python',
-          '-c',
-          "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health')",
-        ]
+      test: ['CMD', 'curl', '-f', 'http://localhost:8000/api/health']
       interval: 10s
       timeout: 5s
-      retries: 5
-      start_period: 30s
+      retries: 12
+      start_period: 60s
 
   frontend:
     build:
       context: .
       dockerfile: Dockerfile.dev
+    dns:
+      - 8.8.8.8
+      - 8.8.4.4
     ports:
       - '3000:3000'
     volumes:
       - .:/app
       - /app/node_modules
     environment:
-      VITE_API_URL: http://backend:8000
+      VITE_PROXY_TARGET: http://backend:8000
     depends_on:
       backend:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+services:
+  backend:
+    image: python:3.12-slim
+    working_dir: /app
+    command: >
+      bash -c "pip install -e '.[api]' --quiet &&
+               branes api serve --host 0.0.0.0 --port 8000"
+    ports:
+      - '8000:8000'
+    volumes:
+      - ../embodied-ai-architect:/app
+      - ~/.embodied-ai:/root/.embodied-ai:ro
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'python',
+          '-c',
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/api/health')",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  frontend:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    ports:
+      - '3000:3000'
+    volumes:
+      - .:/app
+      - /app/node_modules
+    environment:
+      VITE_API_URL: http://backend:8000
+    depends_on:
+      backend:
+        condition: service_healthy

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     port: 3000,
     proxy: {
       '/api': {
-        target: 'http://localhost:8000',
+        target: process.env.VITE_PROXY_TARGET ?? 'http://localhost:8000',
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary

- **docker-compose.yml**: single `docker compose up` starts both frontend and backend
- **Backend service**: `python:3.12-slim` with `embodied-ai-architect` repo mounted, pip installs on startup, serves API on :8000
- **Frontend service**: `Dockerfile.dev` with Node 22, Vite dev server on :3000, source mounted for HMR
- Session data mounted read-only from `~/.embodied-ai`
- Backend healthcheck ensures frontend waits for API readiness before starting
- README updated with Docker Compose usage

## Changes

- `docker-compose.yml` — new file
- `Dockerfile.dev` — new lightweight dev image
- `README.md` — added Docker Compose section

## Test plan

- [x] Fast CI passes (lint + typecheck + build)
- [x] `docker compose up` starts both services
- [x] Backend responds at http://localhost:8000/api/health
- [x] Frontend accessible at http://localhost:3000
- [x] Frontend proxies /api requests to backend

Resolves #14

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a development container for the frontend and Docker Compose setup to run frontend and backend together.
  * Frontend available at :3000, backend at :8000; single-command startup for local dev.

* **Documentation**
  * README updated with Compose setup, required repo layout, session-directory mounting (read-only), environment config, and Windows/WSL2 notes.

* **Chores**
  * Dev server proxy target made configurable via environment variable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->